### PR TITLE
Fix image release to heroku after update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,16 @@ jobs:
       after_script:
         - docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}" ${REGISTRY_URL}
         - docker push "${IMAGE_NAME}:${IMAGE_TAG}"
+        - 'curl -n -X PATCH \
+          -d "{
+            \"updates\": [{
+              \"type\": \"web\",
+              \"docker_image\": \"$(docker inspect \"${IMAGE_NAME}:${IMAGE_TAG}\" --format={{.Id}})\"
+            }]
+          }" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
+          https://api.heroku.com/apps/${HEROKU_APP}/formation'
       branches:
         only:
         - master


### PR DESCRIPTION
Added image release command based on
https://devcenter.heroku.com/articles/container-registry-and-runtime#releasing-an-image

I found no way of executing the command through docker cli therefore it
currently uses curl command.